### PR TITLE
Refresh of mashup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ docker build --tag qlik-mashup .
 Change ./chart/qlik-mashup/values.yaml to point to the docker image you just built.  
 
 From:
-```
+```yaml
 repository: jimareed/qlik-mashup
 ```
 
 To:
-```
+```yaml
 repository: qlik-mashup
 ```
 
@@ -51,11 +51,27 @@ The values.yaml and templates/ingress.yaml files defines an ingress which expose
 
 Referring to a locally built image works if you are using Kubernetes with Docker for Mac but it may not work for Minicube or cloud based kubernetes clusters.  If you have trouble using a local image, then add the image to a docker registry that your Kubernetes cluster has access to.
 
-#### 4. Upgrade the chart
+#### 4. Update helm chart values to point to your target qsefe helm release name
+
+From:
+
+```yaml
+ingress:
+  targetAuthReleaseName: qsefe
+```
+
+To:
+
+```yaml
+ingress:
+  targetAuthReleaseName: my-qsefe-release
+```
+
+#### 5. Upgrade/install the chart in the same namespace as qsefe
 ```
 helm upgrade qlik-mashup ./chart/qlik-mashup
 ```
-#### 4. Open the mashup
+#### 6. Open the mashup
 
 You should be able to open the mashup after making these changes.
 > browse to https://elastic.example/extensions/{mashup}/{mashup}.html

--- a/chart/qlik-mashup/templates/ingress.yaml
+++ b/chart/qlik-mashup/templates/ingress.yaml
@@ -9,7 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: {{ default (printf "http://qsefe-edge-auth.%s.svc.cluster.local:8080/v1/auth" .Release.Namespace ) .Values.ingress.authURL | quote }}
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-url: {{ printf "http://%s-edge-auth.%s.svc.cluster.local:8080/v1/auth" .Values.ingress.targetAuthReleaseName .Release.Namespace | quote }}
     nginx.ingress.kubernetes.io/auth-signin: https://$host/login?returnto=$request_uri
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}

--- a/chart/qlik-mashup/values.yaml
+++ b/chart/qlik-mashup/values.yaml
@@ -14,10 +14,11 @@ service:
   port: 2015
 
 ingress:
+  ## targetAuthReleaseName is the name of the helm release to target for authentication (i.e. the qsefe release name)
+  targetAuthReleaseName: qsefe
   ## Annotations to be added to the ingress.
   ##
   annotations:
-    kubernetes.io/ingress.class: nginx
     ## App is served at root
     nginx.ingress.kubernetes.io/rewrite-target: "/extensions"
     ## Resources of the Single-Page-App are relative to the root


### PR DESCRIPTION
Signed-off-by: Louis Cloutier <louis.cloutier@qlik.com>

1. Fix some minor things in readme
2. Add new `ingress.targetAuthReleaseName` flag to replace the undocumented `ingress.authURL` flag and make it simpler to use (i.e. don't need to specify the entire auth url)
3. Add some details about installing in the correct namespace
4. Fix step numbering
5. Move ingress class definition right into the ingress definition.